### PR TITLE
New RIPPER MODE with DELAY_ROM_EMULATION

### DIFF
--- a/romemul/config.c
+++ b/romemul/config.c
@@ -4,6 +4,7 @@
 // DONT FORGET TO CHANGE MAX_ENTRIES if the number of value changes!
 static ConfigEntry defaultEntries[MAX_ENTRIES] = {
     {"BOOT_FEATURE", TYPE_STRING, "CONFIGURATOR"},
+    {"DELAY_ROM_EMULATION", TYPE_BOOL, "false"},
     {"HOSTNAME", TYPE_STRING, "sidecart"},
     {"ROMS_FOLDER", TYPE_STRING, "/roms"},
     {"ROMS_YAML_URL", TYPE_STRING, "http://roms.sidecart.xyz/roms.json"},

--- a/romemul/include/config.h
+++ b/romemul/include/config.h
@@ -19,7 +19,7 @@
 #include <hardware/flash.h>
 #include <hardware/sync.h>
 
-#define MAX_ENTRIES 7
+#define MAX_ENTRIES 8
 #define MAX_KEY_LENGTH 20
 #define MAX_STRING_VALUE_LENGTH 64
 

--- a/romemul/main.c
+++ b/romemul/main.c
@@ -95,6 +95,24 @@ int main()
     {
         printf("No SELECT button pressed. ROM_EMULATOR entry found in config. Launching.\n");
 
+        // Check if Delay ROM emulation (ripper style boot) is true
+        ConfigEntry *rom_delay_config_entry = find_entry("DELAY_ROM_EMULATION");
+        printf("DELAY_ROM_EMULATION: %s\n", rom_delay_config_entry->value);
+        if ((strcmp(rom_delay_config_entry->value, "true") == 0) || (strcmp(rom_delay_config_entry->value, "TRUE") == 0) || (strcmp(rom_delay_config_entry->value, "T") == 0))
+        {
+            printf("Delaying ROM emulation.\n");
+            // The "D" character stands for "D"
+            blink_morse('D');
+
+            // While until the user presses the SELECT button again to launch the ROM emulator
+            while (gpio_get(5) == 0)
+            {
+                tight_loop_contents();
+                sleep_ms(1000); // Give me a break... to display the message
+            }
+            printf("SELECT button pressed. Launching ROM emulator.\n");
+        }
+
         // Canonical way to initialize the ROM emulator:
         // No IRQ handler callbacks, copy the FLASH ROMs to RAM, and start the state machine
         init_romemul(NULL, NULL, true);


### PR DESCRIPTION
## Background:
The 'Ultimate Ripper' software exhibits a specific behavior when handling the programs to rip:
- The 'Ultimate Ripper' cartridge is plugged in, but with its power switched off, thus the ROMs aren't loaded.
- Users then load the application meant for ripping.
- Next, they press and hold the computer's RESET button while activating the cartridge.
- Upon releasing the RESET button, the ROM-based ripper takes charge of the computer.

## Changes applied
1. **New `DELAY_ROM_EMULATION` Flag**:
   - This configuration flag determines the boot behavior of the ROMs.
  
2. **Behavior with `DELAY_ROM_EMULATION` set to TRUE**:
   - In EMULATOR mode, SidecarT initiates, but the ROM's memory range in the RP2040 remains unallocated. Like an unglugged cartridge. The Pico board will flash a 'D' (DELAY) in Morse, instead of the ROM emulator's classic 'E' (EMULATE).
   
3. **Switching to Classic EMULATOR Mode**:
   - Holding the SELECT button for over a second makes SidecarT revert to the classic EMULATOR mode.
   
4. **Transition to CONFIGURATOR Mode**:
   - If the SELECT button is pressed again after the above step, the device switches to CONFIGURATOR mode, consistent with its usual behavior.
