### PR TITLE
DPRINT macro

### DIFF
--- a/romemul/CMakeLists.txt
+++ b/romemul/CMakeLists.txt
@@ -79,6 +79,7 @@ pico_set_binary_type(${PROJECT_NAME} romemul)
 # Fetch the values from the environment variables
 set(RELEASE_VERSION $ENV{RELEASE_VERSION})
 set(RELEASE_DATE $ENV{RELEASE_DATE})
+set(_DEBUG $ENV{DEBUG_MODE})
 
 # If the environment variables are not set, use default values
 if(NOT RELEASE_VERSION)
@@ -89,10 +90,16 @@ if(NOT RELEASE_DATE)
         string(TIMESTAMP CURRENT_DATE_TIME "%Y-%m-%d %H:%M:%S")
         set(RELEASE_DATE ${CURRENT_DATE_TIME})
 endif()
+if (NOT _DEBUG)
+        set(_DEBUG 0)
+endif()
 
 # Pass these values to the C compiler
 add_definitions(-DRELEASE_VERSION="${RELEASE_VERSION}")
 add_definitions(-DRELEASE_DATE="${RELEASE_DATE}")
+
+# Pass the _DEBUG flag to the C compiler
+add_definitions(-D_DEBUG=${_DEBUG})
 
 # Optimization Flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")

--- a/romemul/config.c
+++ b/romemul/config.c
@@ -57,7 +57,7 @@ void load_all_entries()
     if (magic != (CONFIG_MAGIC | CONFIG_VERSION))
     {
         // No config found in FLASH. Use default values
-        printf("No config found in FLASH. Using default values.\n");
+        DPRINTF("No config found in FLASH. Using default values.\n");
         return;
     }
 
@@ -249,9 +249,9 @@ size_t get_config_size()
 
 void print_config_table()
 {
-    printf("+--------------------------------+--------------------------------+----------+\n");
-    printf("|              Key               |             Value              |   Type   |\n");
-    printf("+--------------------------------+--------------------------------+----------+\n");
+    DPRINTF("+--------------------------------+--------------------------------+----------+\n");
+    DPRINTF("|              Key               |             Value              |   Type   |\n");
+    DPRINTF("+--------------------------------+--------------------------------+----------+\n");
 
     for (size_t i = 0; i < configData.count; i++)
     {
@@ -286,10 +286,10 @@ void print_config_table()
             break;
         }
 
-        printf("| %-30s | %-30s | %-8s |\n", configData.entries[i].key, valueStr, typeStr);
+        DPRINTF("| %-30s | %-30s | %-8s |\n", configData.entries[i].key, valueStr, typeStr);
     }
 
-    printf("+--------------------------------+--------------------------------+----------+\n");
+    DPRINTF("+--------------------------------+--------------------------------+----------+\n");
 }
 
 void swap_data(uint16_t *dest_ptr_word)

--- a/romemul/floppyemul.c
+++ b/romemul/floppyemul.c
@@ -62,13 +62,13 @@ static int create_BPB(FRESULT *fr, FIL *fsrc)
     BYTE buffer[512];    /* File copy buffer */
     unsigned int br = 0; /* File read/write count */
 
-    printf("Creating BPB from first sector of floppy image\n");
+    DPRINTF("Creating BPB from first sector of floppy image\n");
 
     /* Set read/write pointer to logical sector position */
     *fr = f_lseek(fsrc, 0);
     if (*fr)
     {
-        printf("ERROR: Could not seek to the start of the first sector to create BPB\n");
+        DPRINTF("ERROR: Could not seek to the start of the first sector to create BPB\n");
         f_close(fsrc);
         return (int)*fr; // Check for error in reading
     }
@@ -76,7 +76,7 @@ static int create_BPB(FRESULT *fr, FIL *fsrc)
     *fr = f_read(fsrc, buffer, sizeof buffer, &br); /* Read a chunk of data from the source file */
     if (*fr)
     {
-        printf("ERROR: Could not read the first boot sector to create the BPBP\n");
+        DPRINTF("ERROR: Could not read the first boot sector to create the BPBP\n");
         f_close(fsrc);
         return (int)*fr; // Check for error in reading
     }
@@ -97,18 +97,18 @@ static int create_BPB(FRESULT *fr, FIL *fsrc)
     BpbData[SEC_TRACK + 3] = 0;
     BpbData[DISK_NUMBER] = 0;
 
-    // printf("BpbData[BPB_RECSIZE] = %u\n", BpbData[BPB_RECSIZE]);
-    // printf("BpbData[BPB_CLSIZ] = %u\n", BpbData[BPB_CLSIZ]);
-    // printf("BpbData[BPB_CLSIZB] = %u\n", BpbData[BPB_CLSIZB]);
-    // printf("BpbData[BPB_RDLEN] = %u\n", BpbData[BPB_RDLEN]);
-    // printf("BpbData[BPB_FSIZ] = %u\n", BpbData[BPB_FSIZ]);
-    // printf("BpbData[BPB_FATREC] = %u\n", BpbData[BPB_FATREC]);
-    // printf("BpbData[BPB_DATREC] = %u\n", BpbData[BPB_DATREC]);
-    // printf("BpbData[BPB_NUMCL] = %u\n", BpbData[BPB_NUMCL]);
-    // printf("BpbData[SIDE_COUNT] = %u\n", BpbData[SIDE_COUNT]);
-    // printf("BpbData[SEC_CYL] = %u\n", BpbData[SEC_CYL]);
-    // printf("BpbData[SEC_TRACK] = %u\n", BpbData[SEC_TRACK]);
-    // printf("BpbData[DISK_NUMBER] = %u\n", BpbData[DISK_NUMBER]);
+    // DPRINTF("BpbData[BPB_RECSIZE] = %u\n", BpbData[BPB_RECSIZE]);
+    // DPRINTF("BpbData[BPB_CLSIZ] = %u\n", BpbData[BPB_CLSIZ]);
+    // DPRINTF("BpbData[BPB_CLSIZB] = %u\n", BpbData[BPB_CLSIZB]);
+    // DPRINTF("BpbData[BPB_RDLEN] = %u\n", BpbData[BPB_RDLEN]);
+    // DPRINTF("BpbData[BPB_FSIZ] = %u\n", BpbData[BPB_FSIZ]);
+    // DPRINTF("BpbData[BPB_FATREC] = %u\n", BpbData[BPB_FATREC]);
+    // DPRINTF("BpbData[BPB_DATREC] = %u\n", BpbData[BPB_DATREC]);
+    // DPRINTF("BpbData[BPB_NUMCL] = %u\n", BpbData[BPB_NUMCL]);
+    // DPRINTF("BpbData[SIDE_COUNT] = %u\n", BpbData[SIDE_COUNT]);
+    // DPRINTF("BpbData[SEC_CYL] = %u\n", BpbData[SEC_CYL]);
+    // DPRINTF("BpbData[SEC_TRACK] = %u\n", BpbData[SEC_TRACK]);
+    // DPRINTF("BpbData[DISK_NUMBER] = %u\n", BpbData[DISK_NUMBER]);
     return 0;
 }
 
@@ -122,7 +122,7 @@ static void __not_in_flash_func(handle_protocol_command)(const TransmissionProto
     {
     case FLOPPYEMUL_SAVE_VECTORS:
         // Save the vectors needed for the floppy emulation
-        printf("Command SAVE_VECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
+        DPRINTF("Command SAVE_VECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
         payloadPtr = (uint16_t *)protocol->payload + 2;
         hdv_bpb_payload = ((uint32_t)payloadPtr[0] << 16) | payloadPtr[1];
         payloadPtr += 2;
@@ -137,7 +137,7 @@ static void __not_in_flash_func(handle_protocol_command)(const TransmissionProto
         break;
     case FLOPPYEMUL_READ_SECTORS:
         // Read sectors from the floppy emulator
-        printf("Command READ_SECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
+        DPRINTF("Command READ_SECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
         random_token = ((*((uint32_t *)protocol->payload) & 0xFFFF0000) >> 16) | ((*((uint32_t *)protocol->payload) & 0x0000FFFF) << 16);
         payloadPtr = (uint16_t *)protocol->payload + 2;
         sector_size = *(uint16_t *)payloadPtr++;
@@ -146,16 +146,16 @@ static void __not_in_flash_func(handle_protocol_command)(const TransmissionProto
         break;
     case FLOPPYEMUL_WRITE_SECTORS:
         // Write sectors to the floppy emulator
-        printf("Command WRITE_SECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
+        DPRINTF("Command WRITE_SECTORS (%i) received: %d\n", protocol->command_id, protocol->payload_size);
         break;
     case FLOPPYEMUL_SET_BPB:
         // Set the BPB of the floppy
-        printf("Command SET_BPB (%i) received: %d\n", protocol->command_id, protocol->payload_size);
+        DPRINTF("Command SET_BPB (%i) received: %d\n", protocol->command_id, protocol->payload_size);
         random_token = ((*((uint32_t *)protocol->payload) & 0xFFFF0000) >> 16) | ((*((uint32_t *)protocol->payload) & 0x0000FFFF) << 16);
         set_bpb = true;
         break;
     case FLOPPYEMUL_PING:
-        printf("Command PING (%i) received: %d\n", protocol->command_id, protocol->payload_size);
+        DPRINTF("Command PING (%i) received: %d\n", protocol->command_id, protocol->payload_size);
         if (file_ready_a)
         {
             random_token = ((*((uint32_t *)protocol->payload) & 0xFFFF0000) >> 16) | ((*((uint32_t *)protocol->payload) & 0x0000FFFF) << 16);
@@ -163,7 +163,7 @@ static void __not_in_flash_func(handle_protocol_command)(const TransmissionProto
         ping_received = file_ready_a;
         break; // ... handle other commands
     default:
-        printf("Unknown command: %d\n", protocol->command_id);
+        DPRINTF("Unknown command: %d\n", protocol->command_id);
     }
 }
 
@@ -177,7 +177,7 @@ void __not_in_flash_func(floppyemul_dma_irq_handler_lookup_callback)(void)
     uint32_t addr = (uint32_t)dma_hw->ch[lookup_data_rom_dma_channel].al3_read_addr_trig;
 
     // Avoid priting anything inside an IRQ handled function
-    // printf("DMA LOOKUP: $%x\n", addr);
+    // DPRINTF("DMA LOOKUP: $%x\n", addr);
     if (addr >= ROM3_START_ADDRESS)
     {
         parse_protocol((uint16_t)(addr & 0xFFFF), handle_protocol_command);
@@ -195,7 +195,7 @@ int copy_floppy_firmware_to_RAM()
         uint16_t value = *rom4_src++;
         *rom4_dest++ = value;
     }
-    printf("Floppy emulation firmware copied to RAM.\n");
+    DPRINTF("Floppy emulation firmware copied to RAM.\n");
     return 0;
 }
 
@@ -207,12 +207,12 @@ int init_floppyemul()
     bool microsd_mounted = false;
 
     srand(time(0));
-    printf("Initializing floppy emulation...\n");
+    DPRINTF("Initializing floppy emulation...\n");
 
     // Initialize SD card
     if (!sd_init_driver())
     {
-        printf("ERROR: Could not initialize SD card\r\n");
+        DPRINTF("ERROR: Could not initialize SD card\r\n");
         return -1;
     }
     // Mount drive
@@ -220,7 +220,7 @@ int init_floppyemul()
     microsd_mounted = (fr == FR_OK);
     if (!microsd_mounted)
     {
-        printf("ERROR: Could not mount filesystem (%d)\r\n", fr);
+        DPRINTF("ERROR: Could not mount filesystem (%d)\r\n", fr);
         return -1;
     }
     char *dir = find_entry("FLOPPIES_FOLDER")->value;
@@ -229,7 +229,7 @@ int init_floppyemul()
     strcpy(fullpath_a, dir);
     strcat(fullpath_a, "/");
     strcat(fullpath_a, filename_a);
-    printf("Emulating floppy image in drive A: %s\n", fullpath_a);
+    DPRINTF("Emulating floppy image in drive A: %s\n", fullpath_a);
 
     FIL fsrc_a;              /* File objects */
     BYTE buffer_a[512];      /* File copy buffer */
@@ -240,16 +240,16 @@ int init_floppyemul()
     fr = f_open(&fsrc_a, fullpath_a, FA_READ);
     if (fr)
     {
-        printf("ERROR: Could not open file %s (%d)\r\n", fullpath_a, fr);
+        DPRINTF("ERROR: Could not open file %s (%d)\r\n", fullpath_a, fr);
         return -1;
     }
     // Get file size
     size_a = f_size(&fsrc_a);
-    printf("File size of %s: %i bytes\n", fullpath_a, size_a);
+    DPRINTF("File size of %s: %i bytes\n", fullpath_a, size_a);
 
     file_ready_a = true;
 
-    printf("Waiting for commands...\n");
+    DPRINTF("Waiting for commands...\n");
 
     while (true)
     {
@@ -268,7 +268,7 @@ int init_floppyemul()
             int bpb_found = create_BPB(&fr, &fsrc_a);
             if (bpb_found)
             {
-                printf("ERROR: Could not create BPB for image file  %s (%d)\r\n", fullpath_a, fr);
+                DPRINTF("ERROR: Could not create BPB for image file  %s (%d)\r\n", fullpath_a, fr);
                 return -1;
             }
             for (int i = 0; i < sizeof(BpbData) / sizeof(uint16_t); i++)
@@ -282,12 +282,12 @@ int init_floppyemul()
         {
             save_vectors = false;
             // Save the vectors needed for the floppy emulation
-            printf("Saving vectors\n");
-            // printf("XBIOS_trap_payload: %x\n", XBIOS_trap_payload);
-            // printf("hdv_bpb_payload: %x\n", hdv_bpb_payload);
-            // printf("hdv_rw_payload: %x\n", hdv_rw_payload);
-            // printf("hdv_mediach_payload: %x\n", hdv_mediach_payload);
-            // printf("random token: %x\n", random_token);
+            DPRINTF("Saving vectors\n");
+            // DPRINTF("XBIOS_trap_payload: %x\n", XBIOS_trap_payload);
+            // DPRINTF("hdv_bpb_payload: %x\n", hdv_bpb_payload);
+            // DPRINTF("hdv_rw_payload: %x\n", hdv_rw_payload);
+            // DPRINTF("hdv_mediach_payload: %x\n", hdv_mediach_payload);
+            // DPRINTF("random token: %x\n", random_token);
             *((volatile uint16_t *)(ROM4_START_ADDRESS + FLOPPYEMUL_OLD_XBIOS_TRAP)) = XBIOS_trap_payload & 0xFFFF;
             *((volatile uint16_t *)(ROM4_START_ADDRESS + FLOPPYEMUL_OLD_XBIOS_TRAP + 2)) = XBIOS_trap_payload >> 16;
 
@@ -307,19 +307,19 @@ int init_floppyemul()
         {
             sector_read = false;
             dma_channel_set_irq1_enabled(lookup_data_rom_dma_channel, false);
-            printf("LSECTOR: %i / SSIZE: %i\n", logical_sector, sector_size);
+            DPRINTF("LSECTOR: %i / SSIZE: %i\n", logical_sector, sector_size);
             /* Set read/write pointer to logical sector position */
             fr = f_lseek(&fsrc_a, logical_sector * sector_size);
             if (fr)
             {
-                printf("ERROR: Could not seek file %s (%d). Closing file.\r\n", fullpath_a, fr);
+                DPRINTF("ERROR: Could not seek file %s (%d). Closing file.\r\n", fullpath_a, fr);
                 f_close(&fsrc_a);
                 //                                return (int)fr; // Check for error in reading
             }
             fr = f_read(&fsrc_a, buffer_a, sizeof buffer_a, &br_a); /* Read a chunk of data from the source file */
             if (fr)
             {
-                printf("ERROR: Could not read file %s (%d). Closing file.\r\n", fullpath_a, fr);
+                DPRINTF("ERROR: Could not read file %s (%d). Closing file.\r\n", fullpath_a, fr);
                 f_close(&fsrc_a);
                 //                                return (int)fr; // Check for error in reading
             }
@@ -338,7 +338,7 @@ int init_floppyemul()
         // If SELECT button is pressed, launch the configurator
         if (gpio_get(5) != 0)
         {
-            printf("SELECT button pressed. Launch configurator.\n");
+            DPRINTF("SELECT button pressed. Launch configurator.\n");
             watchdog_reboot(0, SRAM_END, 10);
             while (1)
                 ;

--- a/romemul/include/config.h
+++ b/romemul/include/config.h
@@ -9,6 +9,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include "debug.h"
 #include "constants.h"
 
 #include <stdio.h>

--- a/romemul/include/debug.h
+++ b/romemul/include/debug.h
@@ -1,0 +1,28 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+/**
+ * @brief A macro to print debug
+ *
+ * @param fmt The format string for the debug message, similar to printf.
+ * @param ... Variadic arguments corresponding to the format specifiers in the fmt parameter.
+ */
+#ifdef _DEBUG
+#define DPRINTF(fmt, ...)                                                                  \
+    do                                                                                     \
+    {                                                                                      \
+        const char *file = strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__; \
+        fprintf(stderr, "%s:%d:%s(): " fmt "", file,                                       \
+                __LINE__, __func__, ##__VA_ARGS__);                                        \
+    } while (0)
+#define DPRINTFRAW(fmt, ...)                 \
+    do                                       \
+    {                                        \
+        fprintf(stderr, fmt, ##__VA_ARGS__); \
+    } while (0)
+
+#else
+#define DPRINTF(fmt, ...)
+#endif
+
+#endif // DEBUG_H

--- a/romemul/include/floppyemul.h
+++ b/romemul/include/floppyemul.h
@@ -9,6 +9,7 @@
 #ifndef FLOPPYEMUL_H
 #define FLOPPYEMUL_H
 
+#include "debug.h"
 #include "constants.h"
 #include "firmware_floppyemul.h"
 

--- a/romemul/include/network.h
+++ b/romemul/include/network.h
@@ -9,6 +9,7 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
+#include "debug.h"
 #include "constants.h"
 #include "firmware.h"
 #include "config.h"

--- a/romemul/include/romemul.h
+++ b/romemul/include/romemul.h
@@ -9,6 +9,7 @@
 #ifndef ROMEMUL_H
 #define ROMEMUL_H
 
+#include "debug.h"
 #include "constants.h"
 
 #include <inttypes.h>
@@ -22,73 +23,6 @@
 #include "pico/cyw43_arch.h"
 
 #include "../../build/romemul.pio.h"
-
-// Debug macros
-#ifdef _DEBUG
-#include <time.h>
-#include <sys/time.h>
-/**
- * @brief A macro to print debug information with timestamp.
- *
- * This macro is designed to print debug information with a timestamp.
- * It uses the gettimeofday function to get the current time with precision down to the microsecond.
- * The time is then formatted into a more human-readable timestamp.
- *
- * The debug message is printed either to stderr or to a file if the environment variable 'LOG_FILE' is set.
- * When writing to a file, it ensures the message is written immediately by calling fflush.
- *
- * @param fmt The format string for the debug message, similar to printf.
- * @param ... Variadic arguments corresponding to the format specifiers in the fmt parameter.
- */
-#define DEBUG_PRINT(fmt, ...)                                                                              \
-    do                                                                                                     \
-    {                                                                                                      \
-        struct timeval tv;                                                                                 \
-        gettimeofday(&tv, NULL);                                                                           \
-        time_t rawtime = tv.tv_sec;                                                                        \
-        struct tm *ptm = localtime(&rawtime);                                                              \
-        char buffDbg[25];                                                                                  \
-        strftime(buffDbg, sizeof(buffDbg), "%d/%m/%y - %H:%M:%S", ptm);                                    \
-        if (getenv("LOG_FILE") != NULL)                                                                    \
-        {                                                                                                  \
-            if (debug_file == NULL)                                                                        \
-                debug_file = fopen(getenv("LOG_FILE"), "a");                                               \
-            if (debug_file != NULL)                                                                        \
-            {                                                                                              \
-                fprintf(debug_file, "%s.%03ld - DEBUG - " fmt, buffDbg, tv.tv_usec / 1000, ##__VA_ARGS__); \
-                fflush(debug_file);                                                                        \
-            }                                                                                              \
-        }                                                                                                  \
-        else                                                                                               \
-        {                                                                                                  \
-            fprintf(stderr, "%s.%03ld - DEBUG - " fmt, buffDbg, tv.tv_usec / 1000, ##__VA_ARGS__);         \
-        }                                                                                                  \
-    } while (0)
-/**
- * @brief Prints a 32-bit unsigned integer value in binary format.
- *
- * This macro takes a 32-bit unsigned integer value as input and prints it in binary format,
- * with bits being printed from MSB to LSB. Spaces are inserted every 8 bits for better readability.
- *
- * @param value The 32-bit unsigned integer value to print in binary format.
- */
-#define PRINT_BINARY(value)                                \
-    do                                                     \
-    {                                                      \
-        for (int bitIndex = 31; bitIndex >= 0; --bitIndex) \
-        {                                                  \
-            printf("%d", ((value) >> bitIndex) & 1);       \
-            if (bitIndex % 8 == 0)                         \
-            {                                              \
-                printf(" ");                               \
-            }                                              \
-        }                                                  \
-        printf("\n");                                      \
-    } while (0)
-#else
-#define DEBUG_PRINT(fmt, ...)
-#define PRINT_BINARY(value)
-#endif
 
 typedef void (*IRQInterceptionCallback)();
 

--- a/romemul/include/romloader.h
+++ b/romemul/include/romloader.h
@@ -9,6 +9,7 @@
 #ifndef ROMLOADER_H
 #define ROMLOADER_H
 
+#include "debug.h"
 #include "constants.h"
 #include "firmware.h"
 

--- a/romemul/include/tprotocol.h
+++ b/romemul/include/tprotocol.h
@@ -9,6 +9,7 @@
 #ifndef TPROTOCOL_H
 #define TPROTOCOL_H
 
+#include "debug.h"
 #include "constants.h"
 
 #include <stdio.h>

--- a/romemul/main.c
+++ b/romemul/main.c
@@ -84,7 +84,7 @@ int main()
     // Init the CYW43 WiFi module
     if (cyw43_arch_init())
     {
-        printf("Wi-Fi init failed\n");
+        DPRINTF("Wi-Fi init failed\n");
         return -1;
     }
 
@@ -92,14 +92,14 @@ int main()
     load_all_entries();
 
     ConfigEntry *default_config_entry = find_entry("BOOT_FEATURE");
-    printf("BOOT_FEATURE: %s\n", default_config_entry->value);
+    DPRINTF("BOOT_FEATURE: %s\n", default_config_entry->value);
 
     if ((gpio_get(5) == 0) && (strcmp(default_config_entry->value, "CONFIGURATOR") != 0))
     {
-        printf("No SELECT button pressed. ");
+        DPRINTF("No SELECT button pressed. ");
         if (strcmp(default_config_entry->value, "ROM_EMULATOR") == 0)
         {
-            printf("ROM_EMULATOR entry found in config. Launching.\n");
+            DPRINTF("ROM_EMULATOR entry found in config. Launching.\n");
             // Canonical way to initialize the ROM emulator:
             // No IRQ handler callbacks, copy the FLASH ROMs to RAM, and start the state machine
             init_romemul(NULL, NULL, true);
@@ -114,7 +114,7 @@ int main()
                 sleep_ms(1000); // Give me a break... to display the message
                 if (gpio_get(5) != 0)
                 {
-                    printf("SELECT button pressed. Launch configurator.\n");
+                    DPRINTF("SELECT button pressed. Launch configurator.\n");
                     watchdog_reboot(0, SRAM_END, 10);
                     while (1)
                         ;
@@ -124,7 +124,7 @@ int main()
         }
         if (strcmp(default_config_entry->value, "FLOPPY_EMULATOR") == 0)
         {
-            printf("FLOPPY_EMULATOR entry found in config. Launching.\n");
+            DPRINTF("FLOPPY_EMULATOR entry found in config. Launching.\n");
 
             // Copy the ST floppy firmware emulator to RAM
             copy_floppy_firmware_to_RAM();
@@ -135,7 +135,7 @@ int main()
             // IRQ handler callback to read the commands in ROM3, and NOT copy the FLASH ROMs to RAM
             // and start the state machine
             init_romemul(NULL, floppyemul_dma_irq_handler_lookup_callback, false);
-            printf("Ready to accept commands.\n");
+            DPRINTF("Ready to accept commands.\n");
 
             init_floppyemul();
 
@@ -145,7 +145,7 @@ int main()
                 tight_loop_contents();
                 if (gpio_get(5) != 0)
                 {
-                    printf("SELECT button pressed. Launch configurator.\n");
+                    DPRINTF("SELECT button pressed. Launch configurator.\n");
                     watchdog_reboot(0, SRAM_END, 10);
                     while (1)
                         ;
@@ -154,12 +154,12 @@ int main()
             }
         }
 
-        printf("You should never see this line...\n");
+        DPRINTF("You should never see this line...\n");
         return 0;
     }
     else
     {
-        printf("SELECT button pressed. Launch configurator.\n");
+        DPRINTF("SELECT button pressed. Launch configurator.\n");
 
         // Keep in development mode
         if (strcmp(default_config_entry->value, "CONFIGURATOR") != 0)
@@ -188,7 +188,7 @@ int main()
         // and start the state machine
         init_romemul(NULL, dma_irq_handler_lookup_callback, false);
 
-        printf("Ready to accept commands.\n");
+        DPRINTF("Ready to accept commands.\n");
 
         // The "F" character stands for "Firmware"
         blink_morse('F');
@@ -196,7 +196,7 @@ int main()
         init_firmware();
 
         // Now the user needs to reset or poweroff the board to load the ROMs
-        printf("Rebooting the board.\n");
+        DPRINTF("Rebooting the board.\n");
         sleep_ms(1000); // Give me a break... to display the message
 
         watchdog_reboot(0, SRAM_END, 10);

--- a/romemul/network.c
+++ b/romemul/network.c
@@ -80,18 +80,18 @@ void network_init()
 {
     // Enable the STA mode
     cyw43_arch_enable_sta_mode();
-    printf("STA network mode enabled\n");
+    DPRINTF("STA network mode enabled\n");
 
     // Set hostname
     char *hostname = find_entry("HOSTNAME")->value;
     netif_set_hostname(netif_default, hostname + '\0');
-    printf("Hostname: %s\n", hostname);
+    DPRINTF("Hostname: %s\n", hostname);
 
     // Initialize the scan data
     wifiScanData.magic = NETWORK_MAGIC;
     memset(wifiScanData.networks, 0, sizeof(wifiScanData.networks));
     wifiScanData.count = 0;
-    printf("Scan data initialized\n");
+    DPRINTF("Scan data initialized\n");
 }
 
 void network_scan()
@@ -130,7 +130,7 @@ void network_scan()
                 {
                     wifiScanData.networks[wifiScanData.count] = network;
                     wifiScanData.count++;
-                    printf("Found network %s\n", network.ssid);
+                    DPRINTF("Found network %s\n", network.ssid);
                 }
             }
         }
@@ -138,21 +138,21 @@ void network_scan()
     }
     if (!cyw43_wifi_scan_active(&cyw43_state))
     {
-        printf("Scanning networks...\n");
+        DPRINTF("Scanning networks...\n");
         cyw43_wifi_scan_options_t scan_options = {0};
         int err = cyw43_wifi_scan(&cyw43_state, &scan_options, NULL, scan_result);
         if (err == 0)
         {
-            printf("\nPerforming wifi scan\n");
+            DPRINTF("Performing wifi scan\n");
         }
         else
         {
-            printf("Failed to start scan: %d\n", err);
+            DPRINTF("Failed to start scan: %d\n", err);
         }
     }
     else
     {
-        printf("Scan already in progress\n");
+        DPRINTF("Scan already in progress\n");
     }
 }
 
@@ -161,11 +161,11 @@ void network_disconnect()
     int error = cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
     if (error == 0)
     {
-        printf("Disconnected\n");
+        DPRINTF("Disconnected\n");
     }
     else
     {
-        printf("Failed to disconnect: %d\n", error);
+        DPRINTF("Failed to disconnect: %d\n", error);
     }
     connection_status = DISCONNECTED;
 }
@@ -176,7 +176,7 @@ void network_connect(bool force, bool async)
     {
         if ((connection_status == CONNECTED_WIFI_IP) || (connection_status == CONNECTED_WIFI))
         {
-            printf("Already connected\n");
+            DPRINTF("Already connected\n");
             return;
         }
     }
@@ -184,7 +184,7 @@ void network_connect(bool force, bool async)
     ConfigEntry *ssid = find_entry("WIFI_SSID");
     if (strlen(ssid->value) == 0)
     {
-        printf("No SSID found in config. Can't connect\n");
+        DPRINTF("No SSID found in config. Can't connect\n");
         connection_status = DISCONNECTED;
         return;
     }
@@ -198,10 +198,10 @@ void network_connect(bool force, bool async)
     }
     else
     {
-        printf("No password found in config. Trying to connect without password\n");
+        DPRINTF("No password found in config. Trying to connect without password\n");
     }
     uint32_t auth_value = get_auth_pico_code(atoi(auth_mode->value));
-    printf("Connecting to SSID=%s, password=%s, auth=%08x\n", ssid->value, password_value, auth_value);
+    DPRINTF("Connecting to SSID=%s, password=%s, auth=%08x\n", ssid->value, password_value, auth_value);
     int error_code = 0;
     if (!async)
     {
@@ -215,51 +215,51 @@ void network_connect(bool force, bool async)
     if ((error_code == 0) && (async))
     {
         connection_status = CONNECTING;
-        printf("Connecting to SSID=%s\n", ssid->value);
+        DPRINTF("Connecting to SSID=%s\n", ssid->value);
     }
     else
     {
         switch (error_code)
         {
         case PICO_ERROR_TIMEOUT:
-            printf("Failed to connect to SSID=%s. Timeout\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Timeout\n", ssid->value);
             connection_status = TIMEOUT_ERROR;
             break;
         case PICO_ERROR_GENERIC:
-            printf("Failed to connect to SSID=%s. Generic error\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Generic error\n", ssid->value);
             connection_status = GENERIC_ERROR;
             break;
         case PICO_ERROR_NO_DATA:
-            printf("Failed to connect to SSID=%s. No data\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. No data\n", ssid->value);
             connection_status = NO_DATA_ERROR;
             break;
         case PICO_ERROR_NOT_PERMITTED:
-            printf("Failed to connect to SSID=%s. Not permitted\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Not permitted\n", ssid->value);
             connection_status = NOT_PERMITTED_ERROR;
             break;
         case PICO_ERROR_INVALID_ARG:
-            printf("Failed to connect to SSID=%s. Invalid argument\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Invalid argument\n", ssid->value);
             connection_status = INVALID_ARG_ERROR;
             break;
         case PICO_ERROR_IO:
-            printf("Failed to connect to SSID=%s. IO error\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. IO error\n", ssid->value);
             connection_status = IO_ERROR;
             break;
         case PICO_ERROR_BADAUTH:
-            printf("Failed to connect to SSID=%s. Bad auth\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Bad auth\n", ssid->value);
             connection_status = BADAUTH_ERROR;
             break;
         case PICO_ERROR_CONNECT_FAILED:
-            printf("Failed to connect to SSID=%s. Connect failed\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Connect failed\n", ssid->value);
             connection_status = CONNECT_FAILED_ERROR;
             break;
         case PICO_ERROR_INSUFFICIENT_RESOURCES:
-            printf("Failed to connect to SSID=%s. Insufficient resources\n", ssid->value);
+            DPRINTF("Failed to connect to SSID=%s. Insufficient resources\n", ssid->value);
             connection_status = INSUFFICIENT_RESOURCES_ERROR;
             break;
         default:
             connection_status = CONNECTED_WIFI;
-            printf("Connected to SSID=%s\n", ssid->value);
+            DPRINTF("Connected to SSID=%s\n", ssid->value);
         }
     }
 }
@@ -298,22 +298,22 @@ ConnectionStatus get_network_connection_status()
         switch (link_status)
         {
         case CYW43_LINK_DOWN:
-            printf("Link down\n");
+            DPRINTF("Link down\n");
             break;
         case CYW43_LINK_JOIN:
-            printf("Link join. Connected!\n");
+            DPRINTF("Link join. Connected!\n");
             break;
         case CYW43_LINK_FAIL:
-            printf("Link fail\n");
+            DPRINTF("Link fail\n");
             break;
         case CYW43_LINK_NONET:
-            printf("Link no net\n");
+            DPRINTF("Link no net\n");
             break;
         case CYW43_LINK_BADAUTH:
-            printf("Link bad auth\n");
+            DPRINTF("Link bad auth\n");
             break;
         default:
-            printf("Link unknown\n");
+            DPRINTF("Link unknown\n");
         }
     }
     return connection_status;
@@ -536,19 +536,19 @@ void get_json_files(RomInfo **items, int *itemCount, const char *url)
         complete = true;
         if (srv_res != 200)
         {
-            printf("JSON something went wrong. HTTP error: %d\n", srv_res);
+            DPRINTF("JSON something went wrong. HTTP error: %d\n", srv_res);
         }
         else
         {
-            printf("JSON Transfer complete. %d transfered.\n", rx_content_len);
+            DPRINTF("JSON Transfer complete. %d transfered.\n", rx_content_len);
         }
     }
 
     err_t body(void *arg, struct altcp_pcb *conn,
                struct pbuf *p, err_t err)
     {
-        // printf("Body received. ");
-        // printf("Buffer size:%d\n", p->tot_len);
+        // DPRINTF("Body received. ");
+        // DPRINTF("Buffer size:%d\n", p->tot_len);
         // fflush(stdout);
         pbuf_copy_partial(p, (buff + buff_pos), p->tot_len, 0);
         buff_pos += p->tot_len;
@@ -561,16 +561,16 @@ void get_json_files(RomInfo **items, int *itemCount, const char *url)
         return ERR_OK;
     }
 
-    printf("Downloading JSON file from %s\n", url);
+    DPRINTF("Downloading JSON file from %s\n", url);
     if (split_url(url, &parts) != 0)
     {
-        printf("Failed to split URL\n");
+        DPRINTF("Failed to split URL\n");
         return;
     }
 
-    printf("Protocol %s\n", parts.protocol);
-    printf("Domain %s\n", parts.domain);
-    printf("URI %s\n", parts.uri);
+    DPRINTF("Protocol %s\n", parts.protocol);
+    DPRINTF("Domain %s\n", parts.domain);
+    DPRINTF("URI %s\n", parts.uri);
 
     httpc_connection_t settings;
     settings.result_fn = result;
@@ -591,7 +591,7 @@ void get_json_files(RomInfo **items, int *itemCount, const char *url)
 
     if (err != ERR_OK)
     {
-        printf("HTTP GET failed: %d\n", err);
+        DPRINTF("HTTP GET failed: %d\n", err);
         free_url_parts(&parts);
         return;
     }
@@ -631,10 +631,10 @@ void get_json_files(RomInfo **items, int *itemCount, const char *url)
         // Print parsed data as a test
         // for (int i = 0; i < *itemCount; i++)
         // {
-        //     printf("URL: %s\n", (*items)[i].url);
-        //     printf("Name: %s\n", (*items)[i].name);
-        //     printf("Description: %s\n", (*items)[i].description);
-        //     printf("Size (KB): %d\n", (*items)[i].size_kb);
+        //     DPRINTF("URL: %s\n", (*items)[i].url);
+        //     DPRINTF("Name: %s\n", (*items)[i].name);
+        //     DPRINTF("Description: %s\n", (*items)[i].description);
+        //     DPRINTF("Size (KB): %d\n", (*items)[i].size_kb);
         // }
 
         // Free dynamically allocated memory
@@ -671,21 +671,21 @@ int download(const char *url, uint32_t rom_load_offset)
         complete = true;
         if (srv_res != 200)
         {
-            printf("ROM image download something went wrong. HTTP error: %d\n", srv_res);
+            DPRINTF("ROM image download something went wrong. HTTP error: %d\n", srv_res);
         }
         else
         {
-            printf("ROM image transfer complete. %d transfered.\n", rx_content_len);
-            printf("Pending bytes to write: %d\n", flash_buff_pos);
+            DPRINTF("ROM image transfer complete. %d transfered.\n", rx_content_len);
+            DPRINTF("Pending bytes to write: %d\n", flash_buff_pos);
         }
     }
 
     err_t body(void *arg, struct altcp_pcb *conn,
                struct pbuf *p, err_t err)
     {
-        // printf("Body received. ");
-        // printf("Buffer size:%d. ", p->tot_len);
-        // printf("Copying to address: %p\n", dest_address);
+        // DPRINTF("Body received. ");
+        // DPRINTF("Buffer size:%d. ", p->tot_len);
+        // DPRINTF("Copying to address: %p\n", dest_address);
         // fflush(stdout);
 
         // Transform buffer's words from little endian to big endian inline
@@ -697,7 +697,7 @@ int download(const char *url, uint32_t rom_load_offset)
             // Check if the first 4 bytes are 0x0000
             if (buffer[0] == 0x00 && buffer[1] == 0x00 && buffer[2] == 0x00 && buffer[3] == 0x00)
             {
-                printf("Skipping first 4 bytes. Looks like a STEEM cartridge image.\n");
+                DPRINTF("Skipping first 4 bytes. Looks like a STEEM cartridge image.\n");
                 steem_offset = 4;
             }
             first_chunk = false;
@@ -705,19 +705,19 @@ int download(const char *url, uint32_t rom_load_offset)
         uint16_t flash_buffer_current_size = FLASH_BUFFER_SIZE - flash_buff_pos - steem_offset;
         if (total_bytes_copy < flash_buffer_current_size)
         {
-            // printf("Copying %d bytes to address: %p...", (total_bytes_copy - steem_offset), (flash_buff + flash_buff_pos));
+            // DPRINTF("Copying %d bytes to address: %p...", (total_bytes_copy - steem_offset), (flash_buff + flash_buff_pos));
             // THere is room in the flash_buff to copy the whole buffer
             pbuf_copy_partial(p, (flash_buff + flash_buff_pos), (total_bytes_copy - steem_offset), steem_offset);
             // increment the flash buffer position
             flash_buff_pos += (total_bytes_copy - steem_offset);
-            // printf("Done.\n");
+            // DPRINTF("Done.\n");
         }
         else
         {
-            // printf("Copying %d bytes to address: %p...", flash_buffer_current_size, (flash_buff + flash_buff_pos));
+            // DPRINTF("Copying %d bytes to address: %p...", flash_buffer_current_size, (flash_buff + flash_buff_pos));
             // There is no room, so we have to fill it first, invert, write to flash and continue
             pbuf_copy_partial(p, (flash_buff + flash_buff_pos), flash_buffer_current_size, 0);
-            // printf("Done.\n");
+            // DPRINTF("Done.\n");
 
             // Change to big endian
             for (int j = 0; j < FLASH_BUFFER_SIZE; j += 2)
@@ -727,13 +727,13 @@ int download(const char *url, uint32_t rom_load_offset)
             }
 
             // Write chunk to flash
-            printf("Writing %d bytes to address: %p...", flash_buff_pos + flash_buffer_current_size, dest_address);
+            DPRINTF("Writing %d bytes to address: %p...", flash_buff_pos + flash_buffer_current_size, dest_address);
             uint32_t ints = save_and_disable_interrupts();
             flash_range_program(dest_address, flash_buff, FLASH_BUFFER_SIZE);
             restore_interrupts(ints);
             dest_address += FLASH_BUFFER_SIZE;
             flash_buff_pos = 0;
-            printf("Done.\n");
+            DPRINTF("Done.\n");
 
             // Reset the flash buffer position
             flash_buff_pos = 0;
@@ -742,10 +742,10 @@ int download(const char *url, uint32_t rom_load_offset)
             uint16_t bytes_left = total_bytes_copy - flash_buffer_current_size;
             if (bytes_left > 0)
             {
-                // printf("Copying pending %d bytes to address: %p...", bytes_left, (flash_buff + flash_buff_pos));
+                // DPRINTF("Copying pending %d bytes to address: %p...", bytes_left, (flash_buff + flash_buff_pos));
                 pbuf_copy_partial(p, (flash_buff + flash_buff_pos), bytes_left, flash_buffer_current_size);
                 flash_buff_pos += bytes_left;
-                // printf("Done.\n");
+                // DPRINTF("Done.\n");
             }
         }
 
@@ -757,14 +757,14 @@ int download(const char *url, uint32_t rom_load_offset)
         //     flash_buff_pos += 2;
         //     if (flash_buff_pos == FLASH_BUFFER_SIZE)
         //     {
-        //         printf("Writing %d bytes to address: %p...", flash_buff_pos, dest_address);
+        //         DPRINTF("Writing %d bytes to address: %p...", flash_buff_pos, dest_address);
         //         // Disable the flash writing for now until I fix this issue
         //         uint32_t ints = save_and_disable_interrupts();
         //         flash_range_program(dest_address, flash_buff, FLASH_BUFFER_SIZE);
         //         restore_interrupts(ints);
         //         dest_address += FLASH_BUFFER_SIZE;
         //         flash_buff_pos = 0;
-        //         printf("Done.\n");
+        //         DPRINTF("Done.\n");
         //     }
         // }
 
@@ -776,26 +776,26 @@ int download(const char *url, uint32_t rom_load_offset)
         }
         return ERR_OK;
     }
-    printf("Downloading ROM image from %s\n", url);
+    DPRINTF("Downloading ROM image from %s\n", url);
     if (split_url(url, &parts) != 0)
     {
-        printf("Failed to split URL\n");
+        DPRINTF("Failed to split URL\n");
         return -1;
     }
 
-    printf("Protocol %s\n", parts.protocol);
-    printf("Domain %s\n", parts.domain);
-    printf("URI %s\n", parts.uri);
+    DPRINTF("Protocol %s\n", parts.protocol);
+    DPRINTF("Domain %s\n", parts.domain);
+    DPRINTF("URI %s\n", parts.uri);
 
     is_steem = check_STEEM_extension(parts);
 
     // Erase the content before loading the new file. It seems that
     // overwriting it's not enough
-    printf("Erasing FLASH ROM image area at address: %p...\n", rom_load_offset);
+    DPRINTF("Erasing FLASH ROM image area at address: %p...\n", rom_load_offset);
     uint32_t ints = save_and_disable_interrupts();
     flash_range_erase(rom_load_offset, ROM_SIZE_BYTES * 2); // Two banks of 64K
     restore_interrupts(ints);
-    printf("Erased.\n");
+    DPRINTF("Erased.\n");
 
     httpc_connection_t settings;
     memset(&settings, 0, sizeof(settings));
@@ -806,7 +806,7 @@ int download(const char *url, uint32_t rom_load_offset)
 
     complete = false;
     cyw43_arch_lwip_begin();
-    printf("Downloading ROM image from %s\n", url);
+    DPRINTF("Downloading ROM image from %s\n", url);
     err_t err = httpc_get_file_dns(
         parts.domain,
         LWIP_IANA_PORT_HTTP,
@@ -819,13 +819,13 @@ int download(const char *url, uint32_t rom_load_offset)
 
     if (err != ERR_OK)
     {
-        printf("HTTP GET failed: %d\n", err);
+        DPRINTF("HTTP GET failed: %d\n", err);
         free_url_parts(&parts);
         return -1;
     }
     else
     {
-        printf("HTTP GET sent\n");
+        DPRINTF("HTTP GET sent\n");
     }
     while (!complete)
     {

--- a/romemul/romemul.c
+++ b/romemul/romemul.c
@@ -27,12 +27,12 @@ PIO default_pio = pio0;
 // Interrupt handler for DMA completion
 void __not_in_flash_func(dma_irq_handler_lookup)(void)
 {
-    // printf("DMA IRQ\n");
+    // DPRINTF("DMA IRQ\n");
     // Clear the interrupt request for the channel
     dma_hw->ints1 = 1u << 2;
     uint32_t addr = (uint32_t)dma_hw->ch[2].al3_read_addr_trig;
     uint16_t value = *((uint16_t *)addr);
-    printf("DMA LOOKUP: $%x, VALUE: $%x\n", addr, value);
+    DPRINTF("DMA LOOKUP: $%x, VALUE: $%x\n", addr, value);
 
     // Restart the DMA
     //    dma_channel_start(2);
@@ -40,12 +40,12 @@ void __not_in_flash_func(dma_irq_handler_lookup)(void)
 
 void __not_in_flash_func(dma_irq_handler_address)(void)
 {
-    // printf("DMA IRQ\n");
+    // DPRINTF("DMA IRQ\n");
     // Clear the interrupt request for the channel
     dma_hw->ints0 = 1u << 1;
     // uint32_t addr = (uint32_t)dma_hw->ch[2].al3_read_addr_trig;
     // uint16_t value = *((uint16_t *)addr);
-    // printf("DMA ADDR: $%x, VALUE: $%x\n", addr, value);
+    // DPRINTF("DMA ADDR: $%x, VALUE: $%x\n", addr, value);
 
     // Restart the DMA
     //    dma_channel_start(1);
@@ -66,7 +66,7 @@ static int init_monitor_rom4(PIO pio)
     // Enable the state machine
     pio_sm_set_enabled(pio, smMonitorROM4, true);
 
-    printf("ROM4 signal monitor initialized.\n");
+    DPRINTF("ROM4 signal monitor initialized.\n");
     return smMonitorROM4;
 }
 
@@ -86,7 +86,7 @@ static int init_monitor_rom3(PIO pio)
     // Enable the state machine
     pio_sm_set_enabled(pio, smMonitorROM3, true);
 
-    printf("ROM3 signal monitor initialized.\n");
+    DPRINTF("ROM3 signal monitor initialized.\n");
     return smMonitorROM3;
 }
 
@@ -95,22 +95,22 @@ static int init_rom_emulator(PIO pio, IRQInterceptionCallback requestCallback, I
     // Configure DMAs
     // Claim the first available DMA channel for read_addr_rom_dma_channel
     read_addr_rom_dma_channel = dma_claim_unused_channel(true);
-    printf("DMA channel for read_addr_rom_dma_channel: %d\n", read_addr_rom_dma_channel);
+    DPRINTF("DMA channel for read_addr_rom_dma_channel: %d\n", read_addr_rom_dma_channel);
     if (read_addr_rom_dma_channel == -1)
     {
         // Handle the error, perhaps by halting the program or logging an error message
-        printf("Failed to claim a DMA channel for read_addr_rom_dma_channel.\n");
+        DPRINTF("Failed to claim a DMA channel for read_addr_rom_dma_channel.\n");
         dma_channel_unclaim(read_addr_rom_dma_channel);
         return -1;
     }
 
     // Claim another available DMA channel for lookup_data_rom_dma_channel
     lookup_data_rom_dma_channel = dma_claim_unused_channel(true);
-    printf("DMA channel for lookup_data_rom_dma_channel: %d\n", lookup_data_rom_dma_channel);
+    DPRINTF("DMA channel for lookup_data_rom_dma_channel: %d\n", lookup_data_rom_dma_channel);
     if (lookup_data_rom_dma_channel == -1)
     {
         // Handle the error
-        printf("Failed to claim a DMA channel for lookup_data_rom_dma_channel.\n");
+        DPRINTF("Failed to claim a DMA channel for lookup_data_rom_dma_channel.\n");
         // Optionally release the previously claimed channel if you want to clean up
         dma_channel_unclaim(lookup_data_rom_dma_channel);
         return -1;
@@ -174,7 +174,7 @@ static int init_rom_emulator(PIO pio, IRQInterceptionCallback requestCallback, I
     // Use the DMA_IRQ_1 for the read_addr_rom_dma_channel
     if (requestCallback != NULL)
     {
-        printf("Enabling DMA IRQ for read_addr_rom_dma_channel.\n");
+        DPRINTF("Enabling DMA IRQ for read_addr_rom_dma_channel.\n");
         dma_channel_set_irq1_enabled(read_addr_rom_dma_channel, true);
         irq_set_exclusive_handler(DMA_IRQ_1, requestCallback);
         irq_set_enabled(DMA_IRQ_1, true);
@@ -184,13 +184,13 @@ static int init_rom_emulator(PIO pio, IRQInterceptionCallback requestCallback, I
     // Use the DMA_IRQ_1 for the lookup_data_rom_dma_channel
     if (responseCallback != NULL)
     {
-        printf("Enabling DMA IRQ for lookup_data_rom_dma_channel.\n");
+        DPRINTF("Enabling DMA IRQ for lookup_data_rom_dma_channel.\n");
         dma_channel_set_irq1_enabled(lookup_data_rom_dma_channel, true);
         irq_set_exclusive_handler(DMA_IRQ_1, responseCallback);
         irq_set_enabled(DMA_IRQ_1, true);
     }
 
-    printf("ROM emulator initialized.\n");
+    DPRINTF("ROM emulator initialized.\n");
     return smReadROM;
 }
 
@@ -213,7 +213,7 @@ static int copy_FLASH_to_RAM()
         rom_in_ram_dest += sizeof(uint16_t); // Increment by 2 bytes for a word
     }
 
-    printf("FLASH copied to RAM.\n");
+    DPRINTF("FLASH copied to RAM.\n");
     return 0;
 }
 
@@ -232,21 +232,21 @@ int init_romemul(IRQInterceptionCallback requestCallback, IRQInterceptionCallbac
     int smMonitorROM4 = init_monitor_rom4(default_pio);
     if (smMonitorROM4 < 0)
     {
-        printf("Error initializing ROM4 monitor. Error code: %d\n", smMonitorROM4);
+        DPRINTF("Error initializing ROM4 monitor. Error code: %d\n", smMonitorROM4);
         return -1;
     }
 
     int smMonitorROM3 = init_monitor_rom3(default_pio);
     if (smMonitorROM3 < 0)
     {
-        printf("Error initializing ROM3 monitor. Error code: %d\n", smMonitorROM3);
+        DPRINTF("Error initializing ROM3 monitor. Error code: %d\n", smMonitorROM3);
         return -1;
     }
 
     int smReadROM = init_rom_emulator(default_pio, requestCallback, responseCallback);
     if (smReadROM < 0)
     {
-        printf("Error initializing ROM emulator. Error code: %d\n", smReadROM);
+        DPRINTF("Error initializing ROM emulator. Error code: %d\n", smReadROM);
         return -1;
     }
 

--- a/romemul/tprotocol.c
+++ b/romemul/tprotocol.c
@@ -39,7 +39,7 @@ static void __not_in_flash_func(read_payload_size)(uint16_t data)
         // transmission.payload = malloc(transmission.payload_size * sizeof(unsigned char)); // Allocate memory for the payload
         // if (!transmission.payload)
         // { // Ensure memory was allocated successfully
-        //     printf("Error: Could not allocate memory for payload!\n");
+        //     DPRINTF("Error: Could not allocate memory for payload!\n");
         //     exit(1); // Exit or handle the error appropriately
         // }
         //
@@ -87,15 +87,13 @@ void terminate_protocol_parser()
 
 void __not_in_flash_func(process_command)(ProtocolCallback callback)
 {
-    printf("COMMAND: %d / ", transmission.command_id);
-    printf("PAYLOAD SIZE: %d / ", transmission.payload_size);
-    printf("PAYLOAD: ");
+    DPRINTF("COMMAND: %d / PAYLOAD SIZE: %d / PAYLOAD: ", transmission.command_id, transmission.payload_size);
     for (int i = 0; i < transmission.payload_size; i += 2)
     {
         uint16_t value = *((uint16_t *)(&transmission.payload[i]));
-        printf("0x%04X ", value);
+        DPRINTFRAW("0x%04X ", value);
     }
-    printf("\n");
+    DPRINTFRAW("\n");
 
     // Here should pass the transmission message to a function that will handle the different commands
     // I think a good aproach would be to have a callback to custom functions that will handle the different commands
@@ -118,7 +116,7 @@ void __not_in_flash_func(parse_protocol)(uint16_t data, ProtocolCallback callbac
     if (new_header_found - last_header_found > PROTOCOL_READ_RESTART_MICROSECONDS)
     {
         nextTPstep = HEADER_DETECTION;
-        //        printf("Restarting protocol read. Lapse. %i\n", new_header_found - last_header_found);
+        //        DPRINTF("Restarting protocol read. Lapse. %i\n", new_header_found - last_header_found);
     }
     switch (nextTPstep)
     {


### PR DESCRIPTION
Change all `printf` in the code for the macro `DPRINT` and `DPRINTRAW`. 

The reason is more than housekeeping. It seems that the UART (and also any other hardware peripheral of the RP2040) can create bus contention with other peripherals using the RAM and, specifically, the DMAs. Since the ROM emulation is very sensitive to timing, sometimes I find out that random failures are due to excessive trace use. As a result, it's important to have all traces disabled in production release mode.