### PR TITLE
New ROM emulation rescue mode

### DIFF
--- a/romemul/constants.c
+++ b/romemul/constants.c
@@ -47,4 +47,5 @@ MorseCode morseAlphabet[] = {
 };
 
 // Config files constants
-const char WIFI_PASS_FILE_NAME[] = "/.wifipass"; // File name for the wifi password
+const char WIFI_PASS_FILE_NAME[] = "/.wifipass";        // File name for the wifi password
+const char ROM_RESCUE_MODE_FILE_NAME[] = "/.romrescue"; // File name for the rom rescue mode

--- a/romemul/include/constants.h
+++ b/romemul/include/constants.h
@@ -53,6 +53,7 @@ extern const uint32_t CONFIGURATOR_SHARED_MEMORY_SIZE_BYTES;
 
 // Configuration files constants.
 extern const char WIFI_PASS_FILE_NAME[];
+extern const char ROM_RESCUE_MODE_FILE_NAME[];
 
 // Morse code
 #define DOT_DURATION_MS 150


### PR DESCRIPTION
This new feature will work as follows: the user must place in the root folder of the microSD card a new file called .romrescue. In the first line of this file, the user will write the name of the image ROM to boot in rescue mode without the path*, because the Configurator will assume that the prefix path to use is the one used in the ROMS_FOLDER property.

After saving the file, simple start the SidecarT in configurator mode and automatically it will read the image ROM file and will transition to ROM emulation mode. Now simply reboot the Atari ST computer, the ROM image is ready.